### PR TITLE
Always update the scale property of the scope

### DIFF
--- a/dist/angular-pdfjs-viewer.js
+++ b/dist/angular-pdfjs-viewer.js
@@ -461,7 +461,7 @@
                     var pdfViewer = PDFViewerApplication.pdfViewer;
                     
                     if (pdfViewer) {
-                        if ($scope.scale && $scope.scale !== pdfViewer.currentScale) {
+                        if ($scope.scale !== pdfViewer.currentScale) {
                             loaded = {};
                             numLoaded = 0;
                             $scope.scale = pdfViewer.currentScale;

--- a/src/angular-pdfjs-viewer.js
+++ b/src/angular-pdfjs-viewer.js
@@ -92,7 +92,7 @@
                     var pdfViewer = PDFViewerApplication.pdfViewer;
                     
                     if (pdfViewer) {
-                        if ($scope.scale && $scope.scale !== pdfViewer.currentScale) {
+                        if ($scope.scale !== pdfViewer.currentScale) {
                             loaded = {};
                             numLoaded = 0;
                             $scope.scale = pdfViewer.currentScale;


### PR DESCRIPTION
Even when the $scope.scale is `0` or `undefined`.
