### PR TITLE
Ability to disable buttons and change language

### DIFF
--- a/dist/angular-pdfjs-viewer.js
+++ b/dist/angular-pdfjs-viewer.js
@@ -8,7 +8,7 @@
     'use strict';
 
     var module = angular.module('pdfjsViewer', []);
-    
+
     module.provider('pdfjsViewerConfig', function() {
         var config = {
             workerSrc: null,
@@ -17,33 +17,33 @@
             disableWorker: false,
             verbosity: null
         };
-        
+
         this.setWorkerSrc = function(src) {
             config.workerSrc = src;
         };
-        
+
         this.setCmapDir = function(dir) {
             config.cmapDir = dir;
         };
-        
+
         this.setImageDir = function(dir) {
             config.imageDir = dir;
         };
-        
+
         this.disableWorker = function(value) {
             if (typeof value === 'undefined') value = true;
             config.disableWorker = value;
         }
-        
+
         this.setVerbosity = function(level) {
             config.verbosity = level;
         };
-        
+
         this.$get = function() {
             return config;
         }
     });
-    
+
     module.run(['pdfjsViewerConfig', function(pdfjsViewerConfig) {
         if (pdfjsViewerConfig.workerSrc) {
             PDFJS.workerSrc = pdfjsViewerConfig.workerSrc;
@@ -56,7 +56,7 @@
         if (pdfjsViewerConfig.imageDir) {
             PDFJS.imageResourcesPath = pdfjsViewerConfig.imageDir;
         }
-        
+
         if (pdfjsViewerConfig.disableWorker) {
             PDFJS.disableWorker = true;
         }
@@ -64,10 +64,10 @@
         if (pdfjsViewerConfig.verbosity !== null) {
             var level = pdfjsViewerConfig.verbosity;
             if (typeof level === 'string') level = PDFJS.VERBOSITY_LEVELS[level];
-            PDFJS.verbosity = pdfjsViewerConfig.verbosity;
+            PDFJS.verbosity = level;
         }
     }]);
-    
+
     module.directive('pdfjsViewer', ['$interval', function ($interval) {
         return {
             template: '<pdfjs-wrapper>\n' +
@@ -448,18 +448,18 @@
             },
             link: function ($scope, $element, $attrs) {
                 $element.children().wrap('<div class="pdfjs" style="width: 100%; height: 100%;"></div>');
-                
+
                 var initialised = false;
                 var loaded = {};
                 var numLoaded = 0;
 
                 function onPdfInit() {
                     initialised = true;
-                    
+
                     if ($attrs.removeMouseListeners === "true") {
                         window.removeEventListener('DOMMouseScroll', handleMouseWheel);
                         window.removeEventListener('mousewheel', handleMouseWheel);
-                        
+
                         var pages = document.querySelectorAll('.page');
                         angular.forEach(pages, function (page) {
                             angular.element(page).children().css('pointer-events', 'none');
@@ -467,10 +467,10 @@
                     }
                     if ($scope.onInit) $scope.onInit();
                 }
-                
+
                 var poller = $interval(function () {
                     var pdfViewer = PDFViewerApplication.pdfViewer;
-                    
+
                     if (pdfViewer) {
                         if ($scope.scale !== pdfViewer.currentScale) {
                             loaded = {};
@@ -480,25 +480,25 @@
                     } else {
                         console.warn("PDFViewerApplication.pdfViewer is not set");
                     }
-                    
+
                     var pages = document.querySelectorAll('.page');
                     angular.forEach(pages, function (page) {
                         var element = angular.element(page);
                         var pageNum = element.attr('data-page-number');
-                        
+
                         if (!element.attr('data-loaded')) {
                             delete loaded[pageNum];
                             return;
                         }
-                        
+
                         if (pageNum in loaded) return;
 
                         if (!initialised) onPdfInit();
-                        
+
                         if ($scope.onPageLoad) {
                             if ($scope.onPageLoad({page: pageNum}) === false) return;
                         }
-                        
+
                         loaded[pageNum] = true;
                         numLoaded++;
                     });
@@ -553,10 +553,6 @@
                                         buttonSecond.setAttribute('hidden', 'true');
                                     }
                                 }
-
-                                //console.log(document.querySelectorAll('[data-l10n-id="document_properties_version"]')[0].innerHTML);
-                                //console.log(document.querySelectorAll('[data-l10n-id="document_properties_version"]'));
-                                //document.querySelectorAll('[data-l10n-id="document_properties_version"]')[0].innerHTML = "Lululu";
                             }
                         }
                     }
@@ -569,18 +565,16 @@
                                 var items = document.querySelectorAll('[data-l10n-id="'+key+'"]');
                                 for (var i = 0; i < items.length; i++) {
                                     items[i].innerHTML = lang[key];
-                                    console.log(items[i]);
                                 }
-                                console.log(items);
                             }
                         }
                     }
-                    
+
                     PDFJS.webViewerLoad($attrs.src);
                 });
             }
         };
     }]);
 
-    // 
+    //
 }();

--- a/dist/angular-pdfjs-viewer.js
+++ b/dist/angular-pdfjs-viewer.js
@@ -564,7 +564,18 @@
                             if (lang.hasOwnProperty(key)) {
                                 var items = document.querySelectorAll('[data-l10n-id="'+key+'"]');
                                 for (var i = 0; i < items.length; i++) {
-                                    items[i].innerHTML = lang[key];
+                                    if (items[i].tagName === 'BUTTON') {
+                                        items[i].setAttribute('title', lang[key]);
+                                    } else {
+                                        items[i].innerHTML = lang[key];
+                                    }
+                                    console.log(items[i]);
+
+                                }
+                                var itemsLabel = document.querySelectorAll('[data-l10n-id="' + key + '_label"]');
+                                for (var i = 0; i < itemsLabel.length; i++) {
+                                    itemsLabel[i].setAttribute('title', lang[key]);
+                                    itemsLabel[i].innerHTML = lang[key];
                                 }
                             }
                         }

--- a/dist/angular-pdfjs-viewer.js
+++ b/dist/angular-pdfjs-viewer.js
@@ -536,8 +536,23 @@
                         document.getElementById('outerContainer').style.height = $attrs.height;
                     }
 
-                    if ($attrs.buttons) {
-                        var buttons = JSON.parse($attrs.buttons);
+                    PDFJS.webViewerLoad($attrs.src);
+                });
+            }
+        };
+    }]);
+
+    module.config(function ($provide) {
+        $provide.decorator('pdfjsViewerDirective', function ($delegate) {
+            var directive = $delegate[0];
+            var link = directive.link;
+
+            directive.compile = function () {
+                return function (scope, element, attrs) {
+                    link.apply(this, arguments);
+
+                    if (attrs.buttons) {
+                        var buttons = JSON.parse(attrs.buttons);
 
                         for (var key in buttons) {
                             if (buttons.hasOwnProperty(key)) {
@@ -557,12 +572,12 @@
                         }
                     }
 
-                    if ($attrs.lang) {
-                        var lang = JSON.parse($attrs.lang);
+                    if (attrs.lang) {
+                        var lang = JSON.parse(attrs.lang);
 
                         for (var key in lang) {
                             if (lang.hasOwnProperty(key)) {
-                                var items = document.querySelectorAll('[data-l10n-id="'+key+'"]');
+                                var items = document.querySelectorAll('[data-l10n-id="' + key + '"]');
                                 for (var i = 0; i < items.length; i++) {
                                     if (items[i].tagName === 'BUTTON') {
                                         items[i].setAttribute('title', lang[key]);
@@ -578,12 +593,13 @@
                             }
                         }
                     }
+                };
+            };
 
-                    PDFJS.webViewerLoad($attrs.src);
-                });
-            }
-        };
-    }]);
+            return $delegate;
+        });
+
+    });
 
     //
 }();

--- a/dist/angular-pdfjs-viewer.js
+++ b/dist/angular-pdfjs-viewer.js
@@ -569,8 +569,6 @@
                                     } else {
                                         items[i].innerHTML = lang[key];
                                     }
-                                    console.log(items[i]);
-
                                 }
                                 var itemsLabel = document.querySelectorAll('[data-l10n-id="' + key + '_label"]');
                                 for (var i = 0; i < itemsLabel.length; i++) {

--- a/dist/angular-pdfjs-viewer.js
+++ b/dist/angular-pdfjs-viewer.js
@@ -64,7 +64,7 @@
         if (pdfjsViewerConfig.verbosity !== null) {
             var level = pdfjsViewerConfig.verbosity;
             if (typeof level === 'string') level = PDFJS.VERBOSITY_LEVELS[level];
-            PDFJS.verbosity = level;
+            PDFJS.verbosity = pdfjsViewerConfig.verbosity;
         }
     }]);
     
@@ -534,6 +534,46 @@
 
                     if ($attrs.height) {
                         document.getElementById('outerContainer').style.height = $attrs.height;
+                    }
+
+                    if ($attrs.buttons) {
+                        var buttons = JSON.parse($attrs.buttons);
+
+                        for (var key in buttons) {
+                            if (buttons.hasOwnProperty(key)) {
+                                var button = document.getElementById(key);
+                                if (button !== null) {
+                                    if (buttons[key] === false) {
+                                        button.setAttribute('hidden', 'true');
+                                    }
+                                }
+                                var buttonSecond = document.getElementById('secondary' + (key.charAt(0).toUpperCase() + key.slice(1)));
+                                if (buttonSecond !== null) {
+                                    if (buttons[key] === false) {
+                                        buttonSecond.setAttribute('hidden', 'true');
+                                    }
+                                }
+
+                                //console.log(document.querySelectorAll('[data-l10n-id="document_properties_version"]')[0].innerHTML);
+                                //console.log(document.querySelectorAll('[data-l10n-id="document_properties_version"]'));
+                                //document.querySelectorAll('[data-l10n-id="document_properties_version"]')[0].innerHTML = "Lululu";
+                            }
+                        }
+                    }
+
+                    if ($attrs.lang) {
+                        var lang = JSON.parse($attrs.lang);
+
+                        for (var key in lang) {
+                            if (lang.hasOwnProperty(key)) {
+                                var items = document.querySelectorAll('[data-l10n-id="'+key+'"]');
+                                for (var i = 0; i < items.length; i++) {
+                                    items[i].innerHTML = lang[key];
+                                    console.log(items[i]);
+                                }
+                                console.log(items);
+                            }
+                        }
                     }
                     
                     PDFJS.webViewerLoad($attrs.src);

--- a/src/angular-pdfjs-viewer.js
+++ b/src/angular-pdfjs-viewer.js
@@ -195,7 +195,18 @@
                             if (lang.hasOwnProperty(key)) {
                                 var items = document.querySelectorAll('[data-l10n-id="'+key+'"]');
                                 for (var i = 0; i < items.length; i++) {
-                                    items[i].innerHTML = lang[key];
+                                    if (items[i].tagName === 'BUTTON') {
+                                        items[i].setAttribute('title', lang[key]);
+                                    } else {
+                                        items[i].innerHTML = lang[key];
+                                    }
+                                    console.log(items[i]);
+                                    
+                                }
+                                var itemsLabel = document.querySelectorAll('[data-l10n-id="' + key + '_label"]');
+                                for (var i = 0; i < itemsLabel.length; i++) {
+                                    itemsLabel[i].setAttribute('title', lang[key]);
+                                    itemsLabel[i].innerHTML = lang[key];
                                 }
                             }
                         }

--- a/src/angular-pdfjs-viewer.js
+++ b/src/angular-pdfjs-viewer.js
@@ -166,6 +166,40 @@
                     if ($attrs.height) {
                         document.getElementById('outerContainer').style.height = $attrs.height;
                     }
+
+                    if ($attrs.buttons) {
+                        var buttons = JSON.parse($attrs.buttons);
+
+                        for (var key in buttons) {
+                            if (buttons.hasOwnProperty(key)) {
+                                var button = document.getElementById(key);
+                                if (button !== null) {
+                                    if (buttons[key] === false) {
+                                        button.setAttribute('hidden', 'true');
+                                    }
+                                }
+                                var buttonSecond = document.getElementById('secondary' + (key.charAt(0).toUpperCase() + key.slice(1)));
+                                if (buttonSecond !== null) {
+                                    if (buttons[key] === false) {
+                                        buttonSecond.setAttribute('hidden', 'true');
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    if ($attrs.lang) {
+                        var lang = JSON.parse($attrs.lang);
+
+                        for (var key in lang) {
+                            if (lang.hasOwnProperty(key)) {
+                                var items = document.querySelectorAll('[data-l10n-id="'+key+'"]');
+                                for (var i = 0; i < items.length; i++) {
+                                    items[i].innerHTML = lang[key];
+                                }
+                            }
+                        }
+                    }
                     
                     PDFJS.webViewerLoad($attrs.src);
                 });

--- a/src/angular-pdfjs-viewer.js
+++ b/src/angular-pdfjs-viewer.js
@@ -199,9 +199,7 @@
                                         items[i].setAttribute('title', lang[key]);
                                     } else {
                                         items[i].innerHTML = lang[key];
-                                    }
-                                    console.log(items[i]);
-                                    
+                                    } 
                                 }
                                 var itemsLabel = document.querySelectorAll('[data-l10n-id="' + key + '_label"]');
                                 for (var i = 0; i < itemsLabel.length; i++) {

--- a/src/angular-pdfjs-viewer.js
+++ b/src/angular-pdfjs-viewer.js
@@ -166,9 +166,24 @@
                     if ($attrs.height) {
                         document.getElementById('outerContainer').style.height = $attrs.height;
                     }
+                    
+                    PDFJS.webViewerLoad($attrs.src);
+                });
+            }
+        };
+    }]);
 
-                    if ($attrs.buttons) {
-                        var buttons = JSON.parse($attrs.buttons);
+    module.config(function ($provide) {
+        $provide.decorator('pdfjsViewerDirective', function ($delegate) {
+            var directive = $delegate[0];
+            var link = directive.link;
+
+            directive.compile = function () {
+                return function (scope, element, attrs) {
+                    link.apply(this, arguments);
+
+                    if (attrs.buttons) {
+                        var buttons = JSON.parse(attrs.buttons);
 
                         for (var key in buttons) {
                             if (buttons.hasOwnProperty(key)) {
@@ -188,18 +203,18 @@
                         }
                     }
 
-                    if ($attrs.lang) {
-                        var lang = JSON.parse($attrs.lang);
+                    if (attrs.lang) {
+                        var lang = JSON.parse(attrs.lang);
 
                         for (var key in lang) {
                             if (lang.hasOwnProperty(key)) {
-                                var items = document.querySelectorAll('[data-l10n-id="'+key+'"]');
+                                var items = document.querySelectorAll('[data-l10n-id="' + key + '"]');
                                 for (var i = 0; i < items.length; i++) {
                                     if (items[i].tagName === 'BUTTON') {
                                         items[i].setAttribute('title', lang[key]);
                                     } else {
                                         items[i].innerHTML = lang[key];
-                                    } 
+                                    }
                                 }
                                 var itemsLabel = document.querySelectorAll('[data-l10n-id="' + key + '_label"]');
                                 for (var i = 0; i < itemsLabel.length; i++) {
@@ -209,12 +224,13 @@
                             }
                         }
                     }
-                    
-                    PDFJS.webViewerLoad($attrs.src);
-                });
-            }
-        };
-    }]);
+                };
+            };
+
+            return $delegate;
+        });
+
+    });
 
     // === get current script file ===
     var file = {};


### PR DESCRIPTION
Add 2 new attributes: buttons & lang gets a json object. 

Buttons: Use `id` of that button (e.g. `print`)
Lang: Use `data-l10n-id` of that tag

As an example:
`<pdfjs-viewer src="{{ pdf.src }}" buttons='{"print":true,"sidebarToggle":false}' lang='{"find": "Suchen", "print":"Drucken", "findbar": "Im Dokument suchen"}'></pdfjs-viewer>`
