### PR TITLE
Added attribute to set raw data as the source of the pdf

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PDF.js viewer Angular directive
 
-Embed [PDF.js](https://mozilla.github.io/pdf.js/) viewer into your angular application, maintaining that look and feel
+Embed Mozilla's [PDF.js](https://mozilla.github.io/pdf.js/) viewer into your angular application, maintaining that look and feel
 of pdf's we all love. The directive embeds the [full viewer](https://mozilla.github.io/pdf.js/web/viewer.html), which
 allows you to scroll through the pdf.
 
@@ -10,18 +10,16 @@ allows you to scroll through the pdf.
 
 ## Usage
 
-Note that the order of the scripts matters. Stick to the order of dependencies as shown in the example below. Also note
-that images, translations and such are being loaded from the `web` folder.
+Below you will find a basic example of how the directive can be used.
+Note that the order of the scripts matters. Stick to the order of dependencies as shown in the example below.
+Also note that images, translations and such are being loaded from the `web` folder.
 
-**View**
+### View
 ```html
 <!DOCTYPE html>
-<html lang="en" data-ng-app="app" ng-controller="AppCtrl">
+<html ng-app="app" ng-controller="AppCtrl">
     <head>
-        <meta charset="utf-8"/>
         <title>Angular PDF.js demo</title>
-        <meta name="viewport" content="width=device-width, initial-scale=1">
-
         <script src="bower_components/pdf.js-viewer/pdf.js"></script>
         <link rel="stylesheet" href="bower_components/pdf.js-viewer/viewer.css">
 
@@ -30,47 +28,19 @@ that images, translations and such are being loaded from the `web` folder.
         <script src="app.js"></script>
 
         <style>
-          html, body {
-            height: 100%;
-            width: 100%;
-            margin: 0;
-            padding: 0;
-          }
-
-          .some-pdf-container {
-            width: 100%;
-            height: 100%;
-          }
+          html, body { height: 100%; width: 100%; margin: 0; padding: 0; }
+          .some-pdf-container { width: 100%; height: 100%; }
         </style>
     </head>
     <body>
-        <div class='some-pdf-container'>
-            <pdfjs-viewer src="pdf.src" scale="scale"
-                          download="true" print="false" open="false"
-                          on-init="onInit()" on-page-load="onPageLoad(page)">
-            </pdfjs-viewer>
+        <div class="some-pdf-container">
+            <pdfjs-viewer src="{{ pdf.src }}"></pdfjs-viewer>
         </div>
     </body>
 </html>
 ```
 
-Note that the `src` passed in can be either a string (url that points to the pdf) or raw data, 
-as [Uint8Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array).
-See the [demo folder](https://github.com/legalthings/angular-pdfjs-viewer/tree/master/demo) for an example of both.
-
-The `scale` attribute can be used to obtain the current scale (zoom level) of the PDF. This is read only.
-
-The directive takes the following optional attributes to modify the toolbar
-
-    download="false" print="false" open="false"
-
-Omitting these attributes will by default show the options in the toolbar.
-
-The `on-init` function is called when PDF.JS is fully loaded. The `on-page-load` function is each time a page is
-loaded and will pass the page number. When the scale changes all pages are unloaded, so `on-page-load` will be called
-again for each page.
-
-**Controller**
+### Controller
 ```js
 angular.module('app', ['pdfjsViewer']);
 
@@ -78,28 +48,29 @@ angular.module('app').controller('AppCtrl', function($scope) {
     $scope.pdf = {
         src: 'example.pdf',
     };
-    
-    $scope.$watch('scale', function() {
-      ...
-    });
-    
-    $scope.onInit = function() {
-      ...
-    };
-    
-    $scope.onPageLoad = function(page) {
-      ...
-    };
 });
 ```
 
-_If `onPageLoad()` returns `false`, the page will not be marked as loaded and `onPageLoad` will be called again for
-that page on the next (200ms) interval._
+## Directive options
+The `<pdfjs-viewer>` directive takes the following options.
+
+| Attribute(s)  | Description   |
+| ------------- |---------------|
+| src | The `src` should point to the URL of a pdf. This pdf has to be publicly available and should return Content-Type `application/pdf`. The `src` is passed in as an interpolation string, like `src="{{ pdf.src }}"`. |
+| data | In the case that the pdf isn't publicly available you can pass in raw data as a [Uint8Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array) object. See the [demo folder](https://github.com/legalthings/angular-pdfjs-viewer/tree/master/demo) for an example of this. The `data` attribute takes a scope variable as its argument, like `data="pdf.data"`. |
+| scale | The `scale` attribute can be used to obtain the current scale (zoom level) of the PDF. This is read only. |
+| download, print, open | These buttons can be hidden by adding, for example `download="false"` Omitting these attributes will by default show the buttons in the toolbar. |
+| on-init | The `on-init` function is called when PDF.JS is fully loaded. |
+| on-page-load | The `on-page-load` function is each time a page is loaded and will pass the page number. When the scale changes all pages are unloaded, so `on-page-load` will be called again for each page. _If `onPageLoad()` returns `false`, the page will not be marked as loaded and `onPageLoad` will be called again for that page on the next (200ms) interval._ |
+
+## Styling
+Note that the `<pdfjs-viewer>` directive automatically expands to the height and width of its first parent, in this case `.some-pdf-container`
+If no parent container is given the `body` will be used. Height and width are required to properly display the contents of the pdf.
 
 ## Demo
 
-You can test out a demo of this directive. You must run the node server first due to CORS. First make sure
- the dependencies are installed.
+You can test out a [demo](https://github.com/legalthings/angular-pdfjs-viewer/tree/master/demo) of this directive.
+You must run the node server first due to CORS. First make sure the dependencies are installed.
 
     cd demo
     npm install
@@ -133,4 +104,3 @@ Note that a number of images used in the PDF.js viewer are loaded by the `viewer
 through JavaScript. Instead you need to compile the `viewer.less` file as
 
     lessc --global-var='pdfjsImagePath=/assets/pdf.js-viewer/images' viewer.less viewer.css
-

--- a/README.md
+++ b/README.md
@@ -4,12 +4,14 @@ Embed Mozilla's [PDF.js](https://mozilla.github.io/pdf.js/) viewer into your ang
 of pdf's we all love. The directive embeds the [full viewer](https://mozilla.github.io/pdf.js/web/viewer.html), which
 allows you to scroll through the pdf.
 
-## Installation
 
+![viewer-example](https://cloud.githubusercontent.com/assets/5793511/24605022/6dd5abee-1867-11e7-881a-0d68dc7c77f3.png)
+
+
+## Installation
      bower install angular-pdfjs-viewer --save
 
 ## Usage
-
 Below you will find a basic example of how the directive can be used.
 Note that the order of the scripts matters. Stick to the order of dependencies as shown in the example below.
 Also note that images, translations and such are being loaded from the `web` folder.
@@ -52,23 +54,94 @@ angular.module('app').controller('AppCtrl', function($scope) {
 ```
 
 ## Directive options
-The `<pdfjs-viewer>` directive takes the following options.
+The `<pdfjs-viewer>` directive takes the following attributes.
 
-| Attribute(s)  | Description   |
-| ------------- |---------------|
-| src | The `src` should point to the URL of a pdf. This pdf has to be publicly available and should return Content-Type `application/pdf`. The `src` is passed in as an interpolation string, like `src="{{ pdf.src }}"`. |
-| data | In the case that the pdf isn't publicly available you can pass in raw data as a [Uint8Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array) object. See the [demo folder](https://github.com/legalthings/angular-pdfjs-viewer/tree/master/demo) for an example of this. The `data` attribute takes a scope variable as its argument, like `data="pdf.data"`. |
-| scale | The `scale` attribute can be used to obtain the current scale (zoom level) of the PDF. This is read only. |
-| download, print, open | These buttons can be hidden by adding, for example `download="false"` Omitting these attributes will by default show the buttons in the toolbar. |
-| on-init | The `on-init` function is called when PDF.JS is fully loaded. |
-| on-page-load | The `on-page-load` function is each time a page is loaded and will pass the page number. When the scale changes all pages are unloaded, so `on-page-load` will be called again for each page. _If `onPageLoad()` returns `false`, the page will not be marked as loaded and `onPageLoad` will be called again for that page on the next (200ms) interval._ |
+
+#### `src`
+The source should point to the URL of a publicly available pdf.
+Note that the `src` must be passed in as an interpolation string.
+
+```html
+<pdfjs-viewer src="{{ $ctrl.src }}"></pdfjs-viewer>
+```
+
+```javascript
+$scope.src = "http://example.com/file.pdf";
+```
+---
+
+#### `data`
+In the case that you cannot simply use the URL of the pdf, you can pass in raw data as
+a [Uint8Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array) object.
+The `data` attribute takes a scope variable as its argument.
+
+```html
+<pdfjs-viewer data="$ctrl.data"></pdfjs-viewer>
+```
+
+```javascript
+$scope.data = null; // this is loaded async
+
+$http.get("http://example.com/file.pdf", {
+    responseType: 'arraybuffer'
+}).then(function (response) {
+    $scope.data = new Uint8Array(response.data);
+});
+```
+---
+
+#### `scale`
+The `scale` attribute can be used to obtain the current scale (zoom level) of the PDF.
+The value will be stored in the variable specified. **This is read only**.
+
+```html
+<pdfjs-viewer scale="$ctrl.scale"></pdfjs-viewer>
+```
+---
+
+#### `download, print, open`
+These buttons are by default all visible in the toolbar and can be hidden.
+
+```html
+<pdfjs-viewer download="false" print="false" ... ></pdfjs-viewer>
+```
+---
+
+#### `on-init`
+The `on-init` function is called when PDF.JS is fully loaded.
+
+```html
+<pdfjs-viewer on-init="$ctrl.onInit()"></pdfjs-viewer>
+```
+
+```javascript
+$scope.onInit = function () {
+  // pdf.js is initialized
+}
+```
+---
+
+#### `on-page-load`
+The `on-page-load` function is each time a page is loaded and will pass the page number.
+When the scale changes all pages are unloaded, so `on-page-load` will be called again for each page.
+_If `onPageLoad()` returns `false`, the page will not be marked as loaded and `onPageLoad` will be called again for that page on the next (200ms) interval._
+
+```html
+<pdfjs-viewer on-init="$ctrl.onPageLoad()"></pdfjs-viewer>
+```
+
+```javascript
+$scope.onPageLoad = function (page) {
+    // page is loaded
+};
+```
+---
 
 ## Styling
-Note that the `<pdfjs-viewer>` directive automatically expands to the height and width of its first parent, in this case `.some-pdf-container`
-If no parent container is given the `body` will be used. Height and width are required to properly display the contents of the pdf.
+The `<pdfjs-viewer>` directive automatically expands to the height and width of its first immediate parent, in the case of the example `.some-pdf-container`.
+If no parent container is given the html `body` will be used. Height and width are required to properly display the contents of the pdf.
 
 ## Demo
-
 You can test out a [demo](https://github.com/legalthings/angular-pdfjs-viewer/tree/master/demo) of this directive.
 You must run the node server first due to CORS. First make sure the dependencies are installed.
 
@@ -83,7 +156,6 @@ Afterwards run the server like so.
 The server will be running on localhost:8080
 
 ## Advanced configuration
-
 By default the location of PDF.js assets are automatically determined. However if you place them on alternative
 locations they may not be found. If so, you can configure these locations.
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ that images, translations and such are being loaded from the `web` folder.
     </head>
     <body>
         <div class='some-pdf-container'>
-            <pdfjs-viewer src="{{ pdf.src }}" scale="scale"
+            <pdfjs-viewer src="pdf.src" scale="scale"
                           download="true" print="false" open="false"
                           on-init="onInit()" on-page-load="onPageLoad(page)">
             </pdfjs-viewer>
@@ -53,6 +53,10 @@ that images, translations and such are being loaded from the `web` folder.
     </body>
 </html>
 ```
+
+Note that the `src` passed in can be either a string (url that points to the pdf) or raw data, 
+as [Uint8Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array).
+See the [demo folder](https://github.com/legalthings/angular-pdfjs-viewer/tree/master/demo) for an example of both.
 
 The `scale` attribute can be used to obtain the current scale (zoom level) of the PDF. This is read only.
 

--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "angular": "~1.5.8",
-    "pdf.js-viewer": "~1.6.210"
+    "pdf.js-viewer": "~1.6.211"
   },
   "ignore": [
     "**/.*",

--- a/demo/app.js
+++ b/demo/app.js
@@ -1,7 +1,25 @@
 angular.module('app', ['pdfjsViewer']);
 
-angular.module('app').controller('AppCtrl', function($scope) {
+angular.module('app').controller('AppCtrl', function ($scope, $http, $timeout) {
+    var url = 'example.pdf';
+
     $scope.pdf = {
-        src: 'example.pdf'
+        srcAsString: url,
+        srcAsBinary: null
     };
+
+    getPdfAsBinary(url).then(function (response) {
+        $scope.pdf.srcAsBinary = new Uint8Array(response.data);
+    }, function (err) {
+        console.log('failed to get pdf as binary:', err);
+    });
+
+    function getPdfAsBinary (url) {
+        return $http.get(url, {
+            responseType: 'arraybuffer',
+            headers: {
+                'foo': 'bar'
+            }
+        });
+    }
 });

--- a/demo/app.js
+++ b/demo/app.js
@@ -4,17 +4,17 @@ angular.module('app').controller('AppCtrl', function ($scope, $http, $timeout) {
     var url = 'example.pdf';
 
     $scope.pdf = {
-        srcAsString: url,
-        srcAsBinary: null
+        src: url,  // get pdf source from a URL that points to a pdf
+        data: null // get pdf source from raw data of a pdf
     };
 
-    getPdfAsBinary(url).then(function (response) {
-        $scope.pdf.srcAsBinary = new Uint8Array(response.data);
+    getPdfAsArrayBuffer(url).then(function (response) {
+        $scope.pdf.data = new Uint8Array(response.data);
     }, function (err) {
         console.log('failed to get pdf as binary:', err);
     });
 
-    function getPdfAsBinary (url) {
+    function getPdfAsArrayBuffer (url) {
         return $http.get(url, {
             responseType: 'arraybuffer',
             headers: {

--- a/demo/bower.json
+++ b/demo/bower.json
@@ -5,6 +5,6 @@
   "private": "true",
   "dependencies": {
     "angular": "~1.5.8",
-    "pdf.js-viewer": "~1.6.210"
+    "pdf.js-viewer": "~1.6.211"
   }
 }

--- a/demo/index.html
+++ b/demo/index.html
@@ -28,7 +28,11 @@
     </head>
     <body>
         <div class='some-pdf-container'>
-            <pdfjs-viewer src="{{ pdf.src }}"></pdfjs-viewer>
+            <!-- Example of loading pdf from string -->
+            <pdfjs-viewer src="pdf.srcAsString"></pdfjs-viewer>
+
+            <!-- Example of loading pdf from raw binary data. Note comment upper viewer out if you use the viewer below (multi pdf viewers currently not supported) -->
+            <!-- <pdfjs-viewer src="pdf.srcAsBinary"></pdfjs-viewer> -->
         </div>
     </body>
 </html>

--- a/demo/index.html
+++ b/demo/index.html
@@ -28,11 +28,14 @@
     </head>
     <body>
         <div class='some-pdf-container'>
-            <!-- Example of loading pdf from string -->
-            <pdfjs-viewer src="pdf.srcAsString"></pdfjs-viewer>
+            <!-- Example of loading pdf from URL string. Note that this must be an interpolation string -->
+            <pdfjs-viewer src="{{ pdf.src }}"></pdfjs-viewer>
 
-            <!-- Example of loading pdf from raw binary data. Note comment upper viewer out if you use the viewer below (multi pdf viewers currently not supported) -->
-            <!-- <pdfjs-viewer src="pdf.srcAsBinary"></pdfjs-viewer> -->
+            <!-- 
+                Example of loading pdf from raw binary data. Note that this must be a scope variable.
+                Comment upper viewer out if you use this viewer (because multi pdf viewers are currently not supported)
+            -->
+            <!-- <pdfjs-viewer data="pdf.data"></pdfjs-viewer> -->
         </div>
     </body>
 </html>

--- a/dist/angular-pdfjs-viewer.js
+++ b/dist/angular-pdfjs-viewer.js
@@ -379,7 +379,8 @@
                 onInit: '&',
                 onPageLoad: '&',
                 scale: '=?',
-                src: '='
+                src: '@?',
+                data: '=?'
             },
             link: function ($scope, $element, $attrs) {
                 $element.children().wrap('<div class="pdfjs" style="width: 100%; height: 100%;"></div>');
@@ -455,14 +456,18 @@
                 });
 
                 // watch pdf source
-                $scope.$watch(function () {
-                    return $scope.src
-                }, function (src) {
-                    if (!src) {
+                $scope.$watchGroup([
+                    function () { return $scope.src; },
+                    function () { return $scope.data; }
+                ], function (values) {
+                    var src = values[0];
+                    var data = values[1];
+
+                    if (!src && !data) {
                         return;
                     }
 
-                    window.PDFViewerApplication.open(src);
+                    window.PDFViewerApplication.open(src || data);
                 });
 
                 // watch other attributes

--- a/src/angular-pdfjs-viewer.js
+++ b/src/angular-pdfjs-viewer.js
@@ -76,7 +76,8 @@
                 onInit: '&',
                 onPageLoad: '&',
                 scale: '=?',
-                src: '='
+                src: '@?',
+                data: '=?'
             },
             link: function ($scope, $element, $attrs) {
                 $element.children().wrap('<div class="pdfjs" style="width: 100%; height: 100%;"></div>');
@@ -152,14 +153,18 @@
                 });
 
                 // watch pdf source
-                $scope.$watch(function () {
-                    return $scope.src
-                }, function (src) {
-                    if (!src) {
+                $scope.$watchGroup([
+                    function () { return $scope.src; },
+                    function () { return $scope.data; }
+                ], function (values) {
+                    var src = values[0];
+                    var data = values[1];
+
+                    if (!src && !data) {
                         return;
                     }
 
-                    window.PDFViewerApplication.open(src);
+                    window.PDFViewerApplication.open(src || data);
                 });
 
                 // watch other attributes

--- a/src/angular-pdfjs-viewer.js
+++ b/src/angular-pdfjs-viewer.js
@@ -76,6 +76,7 @@
                 onInit: '&',
                 onPageLoad: '&',
                 scale: '=?',
+                src: '='
             },
             link: function ($scope, $element, $attrs) {
                 $element.children().wrap('<div class="pdfjs" style="width: 100%; height: 100%;"></div>');
@@ -83,6 +84,13 @@
                 var initialised = false;
                 var loaded = {};
                 var numLoaded = 0;
+
+                if (!window.PDFJS) {
+                    return console.warn("PDFJS is not set! Make sure that pdf.js is loaded before angular-pdfjs-viewer.js is loaded.");
+                }
+
+                // initialize the pdf viewer with (with empty source)
+                window.PDFJS.webViewerLoad();
 
                 function onPdfInit() {
                     initialised = true;
@@ -100,7 +108,11 @@
                 }
                 
                 var poller = $interval(function () {
-                    var pdfViewer = PDFViewerApplication.pdfViewer;
+                    if (!window.PDFViewerApplication) {
+                        return;
+                    }
+
+                    var pdfViewer = window.PDFViewerApplication.pdfViewer;
                     
                     if (pdfViewer) {
                         if ($scope.scale !== pdfViewer.currentScale) {
@@ -111,7 +123,7 @@
                     } else {
                         console.warn("PDFViewerApplication.pdfViewer is not set");
                     }
-                    
+
                     var pages = document.querySelectorAll('.page');
                     angular.forEach(pages, function (page) {
                         var element = angular.element(page);
@@ -139,11 +151,21 @@
                     $interval.cancel(poller);
                 });
 
+                // watch pdf source
                 $scope.$watch(function () {
-                    return $attrs.src;
-                }, function () {
-                    if (!$attrs.src) return;
+                    return $scope.src
+                }, function (src) {
+                    if (!src) {
+                        return;
+                    }
 
+                    window.PDFViewerApplication.open(src);
+                });
+
+                // watch other attributes
+                $scope.$watch(function () {
+                    return $attrs;
+                }, function () {
                     if ($attrs.open === 'false') {
                         document.getElementById('openFile').setAttribute('hidden', 'true');
                         document.getElementById('secondaryOpenFile').setAttribute('hidden', 'true');
@@ -166,8 +188,6 @@
                     if ($attrs.height) {
                         document.getElementById('outerContainer').style.height = $attrs.height;
                     }
-                    
-                    PDFJS.webViewerLoad($attrs.src);
                 });
             }
         };


### PR DESCRIPTION
We used to pass in the pdf src as a [{{ interpolation }}](https://docs.angularjs.org/guide/expression) string. However this makes it really difficult to open a pdf from binary data.

This PR instead forces us to to pass in [$scope](https://docs.angularjs.org/guide/scope) variables, so we can pass the binary data to the directive. Note that interpolation strings will no longer be supported by the directive, so this is a breaking change.

Aside from passing in a URL string as the source, [PDF.JS by default supports](https://github.com/mozilla/pdf.js/wiki/Frequently-Asked-Questions#can-i-specify-a-different-pdf-in-the-default-viewer) passing a [Uint8Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array) as the source. Now we can actually use that feature in the directive.

It is fairly easy to create a `UInt8Array` from a pdf resource as can be seen in the updated demo file. Because you can just set the [responseType](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/responseType) of a `XMLHttpRequest` to `arraybuffer` and then pass that in the `Uint8Array` constructor.

I also fixed initializing the webviewer with no source. So you can actually load the pdf-viewer without displaying a pdf (for async loaded pdf files). It used to break the view if you passed in `null` as the src.

fixes https://github.com/legalthings/angular-pdfjs-viewer/issues/35 fixes https://github.com/legalthings/angular-pdfjs-viewer/issues/24