### PR TITLE
Fixed IE11 Problem - webViewerLoad needs an empty string

### DIFF
--- a/dist/angular-pdfjs-viewer.js
+++ b/dist/angular-pdfjs-viewer.js
@@ -33,7 +33,7 @@
         this.disableWorker = function(value) {
             if (typeof value === 'undefined') value = true;
             config.disableWorker = value;
-        }
+        };
         
         this.setVerbosity = function(level) {
             config.verbosity = level;
@@ -394,7 +394,7 @@
                 }
 
                 // initialize the pdf viewer with (with empty source)
-                window.PDFJS.webViewerLoad();
+                window.PDFJS.webViewerLoad("");
 
                 function onPdfInit() {
                     initialised = true;

--- a/src/angular-pdfjs-viewer.js
+++ b/src/angular-pdfjs-viewer.js
@@ -33,7 +33,7 @@
         this.disableWorker = function(value) {
             if (typeof value === 'undefined') value = true;
             config.disableWorker = value;
-        }
+        };
         
         this.setVerbosity = function(level) {
             config.verbosity = level;
@@ -91,7 +91,7 @@
                 }
 
                 // initialize the pdf viewer with (with empty source)
-                window.PDFJS.webViewerLoad();
+                window.PDFJS.webViewerLoad("");
 
                 function onPdfInit() {
                     initialised = true;


### PR DESCRIPTION
There is a problem with current master - if you use IE11. The webViewerLoad needs an empty string. Would need urgent an new version.

![image](https://cloud.githubusercontent.com/assets/5563321/24975723/f5be88da-1fc6-11e7-8af8-edc63c4f4dd7.png)

